### PR TITLE
doc: Add note on legacy repo (princess in another castle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Ethereum Alarm Clock Client
 
+**NOTE**: Legacy version, has been moved to
+[pipermerriam/ethereum-alarm-clock](https://github.com/pipermerriam/ethereum-alarm-clock)
+and resides in the tree as [alarm_client](https://github.com/pipermerriam/ethereum-alarm-clock/tree/master/alarm_client).
+That is also the version referenced on [docs.ethereum-alarm-clock.com](http://docs.ethereum-alarm-clock.com).
 
 This is a client that can be used to monitor the alarm service for upcoming
 scheduled calls and execute them when the appropriate block number is reached.


### PR DESCRIPTION
Stumbled upon this repo previously; since online docs mention installing a version of EAC-client that's only tagged [there](https://github.com/pipermerriam/ethereum-alarm-clock/releases), I ~~assume~~ guess this one is historic.

Add a note on new versions elsewhere.

-----

~~Old~~ Big moose, fast dog ([source](https://imgur.com/gallery/WOf64)):

![A large albino moose standing in the bushes, a dog running fast past it](https://i.imgur.com/sjVetyc.jpg)